### PR TITLE
Fix libc++ AUR link

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ sudo apt-get install libc++1
 
 Arch Linux:
 
-[See the AUR page for libc++ for install instructions](https://aur.archlinux.org/packages/libc%2B%2B/)
+[See the Arch package page for libc++ for install instructions](https://archlinux.org/packages/community/x86_64/libc++/)
 
 Fedora:
 


### PR DESCRIPTION
libc++ has been moved into the official Arch Linux repositories, which broke the link to the AUR package. This replaces the broken link with the working link.